### PR TITLE
Fix suffix link bug

### DIFF
--- a/lib/aho_corasick.rb
+++ b/lib/aho_corasick.rb
@@ -42,7 +42,7 @@ class AhoCorasick
     queue = @root.children.to_a.dup
     while !queue.empty?
       char, node = queue.shift
-      node.suffix = node.parent == @root ? @root : (node.parent.suffix && node.parent.suffix.children[char.to_sym])
+      node.suffix = node.parent == @root ? @root : node.find_suffix(char)
       node.children.to_a.each do |entry|
         queue.push(entry)
       end
@@ -71,6 +71,22 @@ class AhoCorasick
 
     def child_for(char)
       @children[char.to_sym] ||= TreeNode.new(self)
+    end
+
+    def find_suffix(char)
+      failure = parent.suffix
+      while !failure.find(char) && failure.parent
+        failure = failure.suffix
+      end
+
+      suffix = failure.find(char)
+      if suffix
+        @matches.push(*suffix.matches)
+      elsif !failure.parent
+        suffix = failure
+      end
+
+      suffix
     end
 
   end

--- a/spec/aho_corasick_spec.rb
+++ b/spec/aho_corasick_spec.rb
@@ -48,4 +48,9 @@ describe "AhoCorasick" do
     a.insert(["cd"])
     expect(a.match("abcd")).to include("cd")
   end
+
+  it "returns overlapping matched substrings correctly" do
+    a = AhoCorasick.new(["cd", "d", "abce"])
+    expect(a.match("abcd").to_set).to eq ["cd", "d"].to_set
+  end
 end


### PR DESCRIPTION
Current behavior:

``` ruby
matcher = AhoCorasick.new(['cd', 'd', 'abce'])
p matcher.match('abcd') #=> ["d"]
# expects: ["cd", "d"]
```

This patch will fix it.
